### PR TITLE
feat: sub as a string is more standard

### DIFF
--- a/src/connectors/oidc-account-adapter.js
+++ b/src/connectors/oidc-account-adapter.js
@@ -32,7 +32,7 @@ export const findAccount = async (ctx, sub, token) => {
       } = user;
 
       return {
-        sub: id, // it is essential to always return a sub claim
+        sub: id.toString(), // it is essential to always return a sub claim
         email,
         email_verified,
         updated_at,


### PR DESCRIPTION
ie. https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2