### PR TITLE
Fix: Grant can be undefined

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -64,7 +64,7 @@ export const provider = {
       // this aligns the Grant ttl with that of the current session
       // if the same Grant is used for multiple sessions, or is set
       // to never expire, you probably do not want this in your code
-      if (ctx.oidc.account && grant.exp < ctx.oidc.session.exp) {
+      if (grant && ctx.oidc.account && grant.exp < ctx.oidc.session.exp) {
         grant.exp = ctx.oidc.session.exp;
 
         await grant.save();


### PR DESCRIPTION
Since commit 913627bea9ada172ceaea7e62857148d432eac19 grant is not always defined and following error arrise : TypeError: Cannot read property 'exp' of undefined