### PR TITLE
fix: unknown_interaction_name consent

### DIFF
--- a/src/controllers/interaction.js
+++ b/src/controllers/interaction.js
@@ -14,7 +14,7 @@ export const interactionStartControllerFactory = provider => async (
 
     req.session.interactionId = interactionId;
 
-    if (prompt.name === 'login') {
+    if (prompt.name === 'login' || prompt.name === 'consent') {
       if (!isEmpty(req.session.user)) {
         return res.redirect(`/interaction/${interactionId}/login`);
       }


### PR DESCRIPTION
Previously in commit 1d3c76f9c1291c6adcbc028dd7cf15ade839d5b9 which
introduces a bunch of modification for the bump oidc-provider v7, there
was in this function conditions on consent prompt.

It is no longer the case, but we currently experienced a lot of 500
error because of an unknown_interaction_name consent.

This commit partially reverts to the previous behaviour (at least for
`consent` prompt, the `login` prompt has been changes too but it is not
changed here, only the `consent` prompt management is restored).

Related https://github.com/betagouv/api-auth/commit/1d3c76f9c1291c6adcbc028dd7cf15ade839d5b9
Related https://sentry.data.gouv.fr/organizations/sentry/issues/13
Related https://mattermost.incubateur.net/betagouv/pl/w71pertnstdtmgjsa7ff5c8axo